### PR TITLE
Corrected virtual environment directory instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ You now have an isolated python installation in the `./nautilus-env/` folder, co
 __Note__: you must activate the `virtualenv` before running the scraper so it uses this virtual python installation
 
 ``` bash
-source youtube-venv/bin/activate
+source nautilus-env/bin/activate
 ```
 
 and then run it:


### PR DESCRIPTION
Contributing.md instructs users to activate `youtube-env/bin/activate` instead of `nautilus-env/bin/activate`. 

This PR corrects [this issue](https://github.com/openzim/nautilus/issues/9).