### PR TITLE
Mandatory Description + LongDescription introduction

### DIFF
--- a/nautiluszim/entrypoint.py
+++ b/nautiluszim/entrypoint.py
@@ -103,7 +103,10 @@ def main():
         "--title", help="Title for your project and ZIM. Otherwise --name.",
     )
     parser.add_argument(
-        "--description", help="Description for your project and ZIM.",
+        "--description", help="Description for your project and ZIM.",required=True,
+    )
+    parser.add_argument(
+        "--longdescription", help=" Long Description for your project and ZIM.",
     )
     parser.add_argument(
         "--creator", help="Name of content creator.",
@@ -164,3 +167,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/nautiluszim/entrypoint.py
+++ b/nautiluszim/entrypoint.py
@@ -9,7 +9,7 @@ from .constants import NAME, SCRAPER, getLogger, setDebug
 
 def main():
     parser = argparse.ArgumentParser(
-        prog=NAME, description="Create a ZIM file off a collection of file documents",
+        prog=NAME, description="Create a ZIM file off a collection of file documents"
     )
 
     parser.add_argument(
@@ -97,20 +97,18 @@ def main():
         dest="locale_name",
     )
     parser.add_argument(
-        "--tags", help="List of comma-separated Tags for the ZIM file.", default="",
+        "--tags", help="List of comma-separated Tags for the ZIM file.", default=""
     )
     parser.add_argument(
-        "--title", help="Title for your project and ZIM. Otherwise --name.",
+        "--title", help="Title for your project and ZIM. Otherwise --name."
     )
     parser.add_argument(
-        "--description", help="Description for your project and ZIM.",required=True,
+        "--description", help="Description for your project and ZIM.", required=True
     )
     parser.add_argument(
-        "--longdescription", help=" Long Description for your project and ZIM.",
+        "--longdescription", help=" Long Description for your project and ZIM."
     )
-    parser.add_argument(
-        "--creator", help="Name of content creator.",
-    )
+    parser.add_argument("--creator", help="Name of content creator.")
     parser.add_argument(
         "--publisher", help="Custom publisher name (ZIM metadata)", default="Kiwix"
     )
@@ -119,9 +117,7 @@ def main():
         help="Custom favicon. Will be resized to 48x48px. Nautilus otherwise.",
     )
     parser.add_argument(
-        "--main-logo",
-        help="Custom logo. Will be resized to 300x65px",
-        dest="main_logo",
+        "--main-logo", help="Custom logo. Will be resized to 300x65px", dest="main_logo"
     )
     parser.add_argument(
         "--secondary-logo",
@@ -167,4 +163,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/nautiluszim/entrypoint.py
+++ b/nautiluszim/entrypoint.py
@@ -9,7 +9,7 @@ from .constants import NAME, SCRAPER, getLogger, setDebug
 
 def main():
     parser = argparse.ArgumentParser(
-        prog=NAME, description="Create a ZIM file off a collection of file documents"
+        prog=NAME, description="Create a ZIM file off a collection of file documents",
     )
 
     parser.add_argument(
@@ -97,18 +97,24 @@ def main():
         dest="locale_name",
     )
     parser.add_argument(
-        "--tags", help="List of comma-separated Tags for the ZIM file.", default=""
+        "--tags", help="List of comma-separated Tags for the ZIM file.", default="",
     )
     parser.add_argument(
-        "--title", help="Title for your project and ZIM. Otherwise --name."
+        "--title", help="Title for your project and ZIM. Otherwise --name.",
     )
     parser.add_argument(
-        "--description", help="Description for your project and ZIM.", required=True
+        "--description", 
+        help="Description for your project and ZIM.",
+        required=True,
     )
     parser.add_argument(
-        "--longdescription", help=" Long Description for your project and ZIM."
+        "--longdescription", 
+        help="Long Description for your project and ZIM.",
     )
-    parser.add_argument("--creator", help="Name of content creator.")
+
+    parser.add_argument(
+        "--creator", help="Name of content creator.",
+    )
     parser.add_argument(
         "--publisher", help="Custom publisher name (ZIM metadata)", default="Kiwix"
     )
@@ -117,7 +123,9 @@ def main():
         help="Custom favicon. Will be resized to 48x48px. Nautilus otherwise.",
     )
     parser.add_argument(
-        "--main-logo", help="Custom logo. Will be resized to 300x65px", dest="main_logo"
+        "--main-logo",
+        help="Custom logo. Will be resized to 300x65px",
+        dest="main_logo",
     )
     parser.add_argument(
         "--secondary-logo",

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -304,27 +304,31 @@ class Nautilus(object):
                 )
 
     def check_long_description_length(self):
-        # Checking if the provided input is a file or text
-        if os.path.isfile(os.path.join(os.getcwd(), self.long_description)):
-            with open(
-                os.path.join(os.getcwd(), self.long_description), "r", encoding="utf-8"
-            ) as fp:
-                text = ""
-                for line in fp:
-                    line = line.strip()
-                    if len(line) >= 4000:
-                        raise ValueError(
-                            f"--The description is greater than 80 characters: {line}"
-                        )
-                    text += line
-                self.long_description = text
+        # checking that user has provided a long description
+        if self.long_description is not None:
+            # Checking if the provided input is a file or text
+            if os.path.isfile(os.path.join(os.getcwd(), self.long_description)):
+                with open(
+                    os.path.join(os.getcwd(), self.long_description),
+                    "r",
+                    encoding="utf-8",
+                ) as fp:
+                    text = ""
+                    for line in fp:
+                        line = line.strip()
+                        if len(line) >= 4000:
+                            raise ValueError(
+                                f"--The description is greater than 80 characters: {line}"
+                            )
+                        text += line
+                    self.long_description = text
 
-        # checking if length is greater than 4000 characters as per openzim Metadata Specification
-        else:
-            if len(self.long_description) >= 4000:
-                raise ValueError(
-                    f"--The long description is greater than 4000 characters: {self.long_description}"
-                )
+            # checking if length is greater than 4000 characters as per openzim Metadata Specification
+            else:
+                if len(self.long_description) >= 4000:
+                    raise ValueError(
+                        f"--The long description is greater than 4000 characters: {self.long_description}"
+                    )
 
     def update_metadata(self):
         self.title = self.title or self.name

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -156,6 +156,10 @@ class Nautilus(object):
 
     def run(self):
         """ execute the scrapper step by step """
+
+        # fail early if description length is greater than 80 characters
+        self.check_description_length()
+
         logger.info(f"starting nautilus scraper for {self.archive}")
 
         logger.info("preparing build folder at {}".format(self.build_dir.resolve()))
@@ -165,12 +169,6 @@ class Nautilus(object):
 
         # fail early if supplied branding files are missing
         self.check_branding_values()
-
-        # fail early if description length is greater than 80 characters
-        self.check_description_length()
-
-        # fail early if long description length is greater than 4000 characters
-        self.check_long_description_length()
 
         # download videos (and recompress)
         if not self.skip_download:
@@ -197,7 +195,7 @@ class Nautilus(object):
                 build_dir=self.build_dir,
                 fpath=self.output_dir / self.fname,
                 main_page="home.html",
-                favicon="favicon.png",
+                illustration="favicon.png",
                 date=datetime.date.today(),
                 **self.zim_info,
             )
@@ -282,58 +280,16 @@ class Nautilus(object):
             )
 
     def check_description_length(self):
-        # Checking if the provided input is a file or text
-        if os.path.isfile(os.path.join(os.getcwd(), self.description)):
-            with open(
-                os.path.join(os.getcwd(), self.description), "r", encoding="utf-8"
-            ) as fp:
-                text = ""
-                for line in fp:
-                    line = line.strip()
-                    if len(line) >= 80:
-                        raise ValueError(
-                            f"--The description is greater than 80 characters: {line}"
-                        )
-                    text += line
-                self.description = text
-
-        else:
-            if len(self.description) >= 80:
+        # Checking if the provided input is a greater than 80 characters
+        if len(self.description) >= 80:
                 raise ValueError(
                     f"--The description is greater than 80 characters: {self.description}"
                 )
-
-    def check_long_description_length(self):
-        # checking that user has provided a long description
-        if self.long_description is not None:
-            # Checking if the provided input is a file or text
-            if os.path.isfile(os.path.join(os.getcwd(), self.long_description)):
-                with open(
-                    os.path.join(os.getcwd(), self.long_description),
-                    "r",
-                    encoding="utf-8",
-                ) as fp:
-                    text = ""
-                    for line in fp:
-                        line = line.strip()
-                        if len(line) >= 4000:
-                            raise ValueError(
-                                f"--The description is greater than 80 characters: {line}"
-                            )
-                        text += line
-                    self.long_description = text
-
-            # checking if length is greater than 4000 characters as per openzim Metadata Specification
-            else:
-                if len(self.long_description) >= 4000:
-                    raise ValueError(
-                        f"--The long description is greater than 4000 characters: {self.long_description}"
-                    )
+            
 
     def update_metadata(self):
         self.title = self.title or self.name
-        self.description = self.description or "-"
-        self.long_description = self.long_description or "..."
+        self.long_description = self.long_description
         self.creator = self.creator or "Unknown"
         self.publisher = self.publisher or "Kiwix"
 
@@ -365,9 +321,17 @@ class Nautilus(object):
         self.secondary_color = self.secondary_color or secondary_color
 
         # get about content from param, archive or defaults to desc
-        self.about_content = (
-            f"<p>{self.description}</p><br><p>{self.long_description}</p>"
-        )
+
+        #setting the about_content to long_description if it is provided by the user
+        if(self.long_description is not None):
+            self.about_content = (
+                f"<p>{self.long_description}</p>"
+            )
+        #setting the about_content to description if long_description is not provided
+        else:
+            self.about_content = (
+                f"<p>{self.description}</p>"
+            )
         about_source = self.build_dir / "about.html"
         if about_source.exists():
             with open(about_source, "r") as fh:
@@ -468,7 +432,6 @@ class Nautilus(object):
                                 "_id": str(docid).zfill(5),
                                 "ti": document.get("title") or "Unknown?",
                                 "dsc": document.get("description") or "",
-                                "longdsc": document.get("long-description") or "",
                                 "aut": document.get("authors") or "",
                                 "fp": document.get("files", []),
                             }

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -67,7 +67,7 @@ class Nautilus(object):
         self.tags = [t.strip() for t in tags.split(",")]
         self.title = title
         self.description = description
-        self.long_description=longdescription;
+        self.long_description = longdescription
         self.creator = creator
         self.publisher = publisher
         self.name = name
@@ -168,8 +168,8 @@ class Nautilus(object):
 
         # fail early if description length is greater than 80 characters
         self.check_description_length()
-        
-        #fail early if long description length is greater than 4000 characters
+
+        # fail early if long description length is greater than 4000 characters
         self.check_long_description_length()
 
         # download videos (and recompress)
@@ -199,7 +199,8 @@ class Nautilus(object):
                 main_page="home.html",
                 favicon="favicon.png",
                 date=datetime.date.today(),
-                **self.zim_info)
+                **self.zim_info,
+            )
             logger.info("removing HTML folder")
             if not self.keep_build_dir:
                 shutil.rmtree(self.build_dir, ignore_errors=True)
@@ -278,14 +279,15 @@ class Nautilus(object):
         if self.about:
             handle_user_provided_file(
                 source=self.about, dest=self.build_dir / "about.html"
-            
             )
-    
+
     def check_description_length(self):
         # Checking if the provided input is a file or text
         if os.path.isfile(os.path.join(os.getcwd(), self.description)):
-            with open(os.path.join(os.getcwd(), self.description), "r", encoding="utf-8") as fp:
-                text=""
+            with open(
+                os.path.join(os.getcwd(), self.description), "r", encoding="utf-8"
+            ) as fp:
+                text = ""
                 for line in fp:
                     line = line.strip()
                     if len(line) >= 80:
@@ -293,42 +295,41 @@ class Nautilus(object):
                             f"--The description is greater than 80 characters: {line}"
                         )
                     text += line
-                self.description=text
-                
-                   
-                
+                self.description = text
+
         else:
             if len(self.description) >= 80:
                 raise ValueError(
                     f"--The description is greater than 80 characters: {self.description}"
                 )
+
     def check_long_description_length(self):
         # Checking if the provided input is a file or text
         if os.path.isfile(os.path.join(os.getcwd(), self.long_description)):
-            with open(os.path.join(os.getcwd(), self.long_description), "r", encoding="utf-8") as fp:
-                text=""
+            with open(
+                os.path.join(os.getcwd(), self.long_description), "r", encoding="utf-8"
+            ) as fp:
+                text = ""
                 for line in fp:
                     line = line.strip()
                     if len(line) >= 4000:
                         raise ValueError(
-                            f"--The long description is greater than 4000 characters: {line}"
+                            f"--The description is greater than 80 characters: {line}"
                         )
                     text += line
-                self.long_description=text
-                
-                   
-        # checking if length is greater than 4000 characters as per openzim Metadata Specification         
+                self.long_description = text
+
+        # checking if length is greater than 4000 characters as per openzim Metadata Specification
         else:
             if len(self.long_description) >= 4000:
                 raise ValueError(
                     f"--The long description is greater than 4000 characters: {self.long_description}"
                 )
 
-
     def update_metadata(self):
         self.title = self.title or self.name
         self.description = self.description or "-"
-        self.long_description=self.long_description or "..."
+        self.long_description = self.long_description or "..."
         self.creator = self.creator or "Unknown"
         self.publisher = self.publisher or "Kiwix"
 
@@ -340,14 +341,15 @@ class Nautilus(object):
             self.build_dir.joinpath("favicon.ico"),
         )
 
-        self.zim_info.update({
-            "title": self.title,
-            "description": self.description,
-            "long_description":self.long_description,
-            "creator": self.creator,
-            "publisher": self.publisher,
-            "name": self.name,
-            "tags": self.tags,
+        self.zim_info.update(
+            {
+                "title": self.title,
+                "description": self.description,
+                "long_description": self.long_description,
+                "creator": self.creator,
+                "publisher": self.publisher,
+                "name": self.name,
+                "tags": self.tags,
             }
         )
 
@@ -359,7 +361,9 @@ class Nautilus(object):
         self.secondary_color = self.secondary_color or secondary_color
 
         # get about content from param, archive or defaults to desc
-        self.about_content = f"<p>{self.description}</p><br><p>{self.long_description}</p>"
+        self.about_content = (
+            f"<p>{self.description}</p><br><p>{self.long_description}</p>"
+        )
         about_source = self.build_dir / "about.html"
         if about_source.exists():
             with open(about_source, "r") as fh:
@@ -467,4 +471,3 @@ class Nautilus(object):
                     )
                 )
             fp.write("];\n")
-

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -46,6 +46,7 @@ class Nautilus(object):
         name=None,
         title=None,
         description=None,
+        longdescription=None,
         creator=None,
         publisher=None,
         favicon=None,
@@ -66,6 +67,7 @@ class Nautilus(object):
         self.tags = [t.strip() for t in tags.split(",")]
         self.title = title
         self.description = description
+        self.long_description=longdescription;
         self.creator = creator
         self.publisher = publisher
         self.name = name
@@ -95,6 +97,7 @@ class Nautilus(object):
             tags=tags,
             title=title,
             description=description,
+            long_description=longdescription,
             creator=creator,
             publisher=publisher,
             name=name,
@@ -162,6 +165,12 @@ class Nautilus(object):
 
         # fail early if supplied branding files are missing
         self.check_branding_values()
+
+        # fail early if description length is greater than 80 characters
+        self.check_description_length()
+        
+        #fail early if long description length is greater than 4000 characters
+        self.check_long_description_length()
 
         # download videos (and recompress)
         if not self.skip_download:
@@ -269,11 +278,57 @@ class Nautilus(object):
         if self.about:
             handle_user_provided_file(
                 source=self.about, dest=self.build_dir / "about.html"
+            
             )
+    
+    def check_description_length(self):
+        # Checking if the provided input is a file or text
+        if os.path.isfile(os.path.join(os.getcwd(), self.description)):
+            with open(os.path.join(os.getcwd(), self.description), "r", encoding="utf-8") as fp:
+                text=""
+                for line in fp:
+                    line = line.strip()
+                    if len(line) >= 80:
+                        raise ValueError(
+                            f"--The description is greater than 80 characters: {line}"
+                        )
+                    text += line
+                self.description=text
+                
+                   
+                
+        else:
+            if len(self.description) >= 80:
+                raise ValueError(
+                    f"--The description is greater than 80 characters: {self.description}"
+                )
+    def check_long_description_length(self):
+        # Checking if the provided input is a file or text
+        if os.path.isfile(os.path.join(os.getcwd(), self.long_description)):
+            with open(os.path.join(os.getcwd(), self.long_description), "r", encoding="utf-8") as fp:
+                text=""
+                for line in fp:
+                    line = line.strip()
+                    if len(line) >= 4000:
+                        raise ValueError(
+                            f"--The description is greater than 80 characters: {line}"
+                        )
+                    text += line
+                self.long_description=text
+                
+                   
+        # checking if length is greater than 4000 characters as per openzim Metadata Specification         
+        else:
+            if len(self.long_description) >= 4000:
+                raise ValueError(
+                    f"--The long description is greater than 4000 characters: {self.long_description}"
+                )
+
 
     def update_metadata(self):
         self.title = self.title or self.name
         self.description = self.description or "-"
+        self.long_description=self.long_description or "..."
         self.creator = self.creator or "Unknown"
         self.publisher = self.publisher or "Kiwix"
 
@@ -288,6 +343,7 @@ class Nautilus(object):
         self.zim_info.update({
             "title": self.title,
             "description": self.description,
+            "long_description":self.long_description,
             "creator": self.creator,
             "publisher": self.publisher,
             "name": self.name,
@@ -303,7 +359,7 @@ class Nautilus(object):
         self.secondary_color = self.secondary_color or secondary_color
 
         # get about content from param, archive or defaults to desc
-        self.about_content = f"<p>{self.description}</p>"
+        self.about_content = f"<p>{self.description}</p><br><p>{self.long_description}</p>"
         about_source = self.build_dir / "about.html"
         if about_source.exists():
             with open(about_source, "r") as fh:
@@ -356,6 +412,7 @@ class Nautilus(object):
             debug=str(self.debug).lower(),
             title=self.title,
             description=self.description,
+            long_description=self.long_description,
             main_color=self.main_color,
             secondary_color=self.secondary_color,
             db_name=f"{self.name}_{self.period}_{uuid.uuid4().hex}_db",
@@ -381,6 +438,7 @@ class Nautilus(object):
             debug=str(self.debug).lower(),
             title=self.title,
             description=self.description,
+            long_description=self.long_description,
             db_name=f"{self.name}_{self.period}_{uuid.uuid4().hex}_db",
             db_version=1,
             nb_items_per_page=self.nb_items_per_page,
@@ -409,3 +467,4 @@ class Nautilus(object):
                     )
                 )
             fp.write("];\n")
+

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -468,6 +468,7 @@ class Nautilus(object):
                                 "_id": str(docid).zfill(5),
                                 "ti": document.get("title") or "Unknown?",
                                 "dsc": document.get("description") or "",
+                                "longdsc": document.get("long-description") or "",
                                 "aut": document.get("authors") or "",
                                 "fp": document.get("files", []),
                             }

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -286,12 +286,12 @@ class Nautilus(object):
     def check_description_length(self):
         if len(self.description) > MAXIMUM_DESCRIPTION_METADATA_LENGTH:
                 raise ValueError(
-                    f"--The description is greater than 80 characters: {len(self.description)} characters"
+                    f"--The description is greater than {MAXIMUM_DESCRIPTION_METADATA_LENGTH} characters: {len(self.description)} characters"
                 )
         if (self.long_description is not None):
             if len(self.long_description) > MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH:
                     raise ValueError(
-                        f"--The Long Description is greater than 4000 characters: {len(self.long_description)} characters"
+                        f"--The Long Description is greater than {MAXIMUM_LONG_DESCRIPTION_METADATA_LENGTH} characters: {len(self.long_description)} characters"
                     )
 
             

--- a/nautiluszim/scraper.py
+++ b/nautiluszim/scraper.py
@@ -311,7 +311,7 @@ class Nautilus(object):
                     line = line.strip()
                     if len(line) >= 4000:
                         raise ValueError(
-                            f"--The description is greater than 80 characters: {line}"
+                            f"--The long description is greater than 4000 characters: {line}"
                         )
                     text += line
                 self.long_description=text

--- a/nautiluszim/templates/init.js
+++ b/nautiluszim/templates/init.js
@@ -3,7 +3,6 @@ $( document ).ready(function() {
     window.nautilus = new Nautilus({
         title: "{{ title|safe }}",
         description: "{{ description|safe }}",
-        long_description: "{{ long_description|safe }}",
         database_name: "{{ db_name }}.{{ db_version }}",
         database_version: "{{ db_version }}",
         nb_items_per_page: {{ nb_items_per_page }},

--- a/nautiluszim/templates/init.js
+++ b/nautiluszim/templates/init.js
@@ -3,6 +3,7 @@ $( document ).ready(function() {
     window.nautilus = new Nautilus({
         title: "{{ title|safe }}",
         description: "{{ description|safe }}",
+        long_description: "{{ long_description|safe }}",
         database_name: "{{ db_name }}.{{ db_version }}",
         database_version: "{{ db_version }}",
         nb_items_per_page: {{ nb_items_per_page }},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jinja2>=3.1.2,<3.2
-zimscraperlib>2.1.0,<=3.0.0
+zimscraperlib>=3.0.0,<4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jinja2>=3.1.2,<3.2
-zimscraperlib>=1.8.0,<1.9
+zimscraperlib>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 jinja2>=3.1.2,<3.2
-zimscraperlib>=3.0.0
+zimscraperlib>2.1.0,<=3.0.0


### PR DESCRIPTION
I have added description as mandatory and checked if the description provided is below 80 characters.
I have also added the option to provide longdescription which has a maximum length of 4000 characters. 
For users to see the longdescription, I have changed the about_content.

I checked if the user has given a file as input or a text as input for both description, longdescription .

I have checked if longdescription was provided before checking the length of the long description.

I have made the following changes in zimscraperlib/zim/filesystem.py for the above code to work:

1)After line 119("description: str,") I added:
                            `long_description:str,`
2)After line 162(""description": description,") I added:
                            `"long_description":long_description,`

These were the changes I made.
